### PR TITLE
Add detection of arm64 architecture for macos builds

### DIFF
--- a/build/macos.inc
+++ b/build/macos.inc
@@ -36,11 +36,15 @@ ifndef arch
      export arch:=ppc32
    endif
  else
+  ifeq ($(shell /usr/sbin/sysctl -n hw.machine),arm64)
+   export arch:=arm64
+  else
    ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
      export arch:=intel64
    else
      export arch:=ia32
    endif
+  endif
  endif
 endif
 


### PR DESCRIPTION
This commit adds detection of arm64 for macos builds on arm64 hardware.
The only change necessary is an additional case in the code where
macos.inc queries and detects the system architecture.